### PR TITLE
Unable to create test report becase TESTOMATIO has special chars

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,11 @@ jobs:
           pip install pytest-json-ctrf
 
       - name: Run tests
-        run: pytest --ctrf $REPORT    #  --testomatio report
+        run: pytest --ctrf $REPORT --testomatio report
         env:
           REPORT: 'test-results/report.json'
           PROC: 'auto'
-          TESTOMATIO: ${{ secrets.TESTOMATIO_API_KEY }}
+          TESTOMATIO: '${{ secrets.TESTOMATIO_API_KEY }}'
           TESTOMATIO_CODE_STYLE: 'pep8'
 
       - name: Generate Pretty Report

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,7 +5,7 @@ from pytest import mark
 def test_post_1(session):
     response = session.get('/posts/1')
     payload = response.json()
-    assert payload['id'] == 2
+    assert payload['id'] == 1
     assert payload['title'] == 'sunt aut facere repellat provident occaecati excepturi optio reprehenderit'
     assert 'recusandae consequuntur expedita' in payload['body']
 


### PR DESCRIPTION
Getting error mesage from github action because run_details is None Object. After checking source code, it unable to create test run because errors. Adding single quote to avoid break errors. 
```
2024-08-24T15:40:22.9793630Z INTERNALERROR>   File "/opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/pytestomatio/main.py", line 54, in pytest_configure
2024-08-24T15:40:22.9794644Z INTERNALERROR>     run_id = run_details.get('uid')
2024-08-24T15:40:22.9795145Z INTERNALERROR>              ^^^^^^^^^^^^^^^
2024-08-24T15:40:22.9795744Z INTERNALERROR> AttributeError: 'NoneType' object has no attribute 'get'
```